### PR TITLE
Handle OSC sequences with empty text parameters

### DIFF
--- a/VtNetCore.Unit.Tests/libvtermStateTerminalProperties.cs
+++ b/VtNetCore.Unit.Tests/libvtermStateTerminalProperties.cs
@@ -126,6 +126,12 @@
             };
 
             // !Title
+            // PUSH "\e]2;\a"
+            //   settermprop 4 ""
+            Push(d, "".ChangeWindowTitle(""));
+            Assert.Equal("", windowTitle);
+
+            // !Title
             // PUSH "\e]2;Here is my title\a"
             //   settermprop 4 "Here is my title"
             Push(d, "".ChangeWindowTitle("Here is my title"));

--- a/VtNetCore/XTermParser/XTermSequenceReader.cs
+++ b/VtNetCore/XTermParser/XTermSequenceReader.cs
@@ -169,6 +169,7 @@
 
                         Parameters.Add(currentParameter);
                         currentParameter = -1;
+                        readingCommand = true;
                     }
                     else if (char.IsDigit(next))
                     {


### PR DESCRIPTION
Previously, the parser only handled sequences with non-empty text
parameters and failed to handle sequences like \e]2;\a or \e]0;\a.

This caused some programs to hang because they did not receive
the expected feedback.

This PR is copy of this PR submitted by [jpassing:](https://github.com/jpassing):
https://github.com/darrenstarr/VtNetCore/pull/11